### PR TITLE
Fix typescript compilation on dedicated server

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
         "typeRoots": [
             "./node_modules"
         ],
+        "types": [
+            "nakama-runtime"
+        ],
         "outFile": "./build/index.js",
         "strict": true,
         "esModuleInterop": true,


### PR DESCRIPTION
Modified tsconfig.json to not look for types in `node_modules/package`. There is probably a better way to fix that but I've tested this on both local and dedicated server and it works.